### PR TITLE
Fix search

### DIFF
--- a/api/app/services/search/options.rb
+++ b/api/app/services/search/options.rb
@@ -165,7 +165,8 @@ module Search
         :request_params,
         :per_page,
         page: :page_number,
-        index_name: :search_indexes
+        index_name: :search_indexes,
+        models: :search_indexes
       )
     end
 

--- a/api/app/services/search/query_builder.rb
+++ b/api/app/services/search/query_builder.rb
@@ -39,7 +39,7 @@ module Search
       search do |s|
         apply_query! s
         apply_highlight! s
-        apply_indices_boost! s
+        # apply_indices_boost! s # Indices boost is incompatible with ES 5.6
         apply_pagination! s
         apply_select! s
       end


### PR DESCRIPTION
Connected to https://github.com/notch8/princeton-manifold/issues/56. 

I originally thought the issue was with indexing (see #58), but it ended up being that the models were not being included in the search, and then the index boost is not compatible with the version of ElasticSearch we are using.

Deployed successfully to production (since staging is currently broken - see #59). 

Prior to fix search api search (https://openpublishing.princeton.edu/api/v1/search_results?keyword=handbook) returned:
```json
{ "data": [], "total_count": 0 }
```

After fix api the same api search returns data with a total count of 194.