### PR TITLE
Update to new nginx-ingress - production cluster

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -15,7 +15,7 @@ readinessProbe:
 
 ingress:
   enabled: true
-  ingressClassName: "nginx-ingress"
+  className: "nginx-ingress"
   hosts:
     - host: openpublishing.princeton.edu
       paths:

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -21,12 +21,17 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
+    - host: princeton-manifold-origin.notch8.cloud
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
   annotations:
     nginx.org/client-max-body-size: "0"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
   tls:
     - hosts:
         - openpublishing.princeton.edu
+        - princeton-manifold-origin.notch8.cloud
       secretName: production-princeton-manifold-tls
 
 api:

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -15,14 +15,14 @@ readinessProbe:
 
 ingress:
   enabled: true
+  ingressClassName: "nginx-ingress"
   hosts:
     - host: openpublishing.princeton.edu
       paths:
         - path: /
           pathType: ImplementationSpecific
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.org/client-max-body-size: "0"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
   tls:
     - hosts:


### PR DESCRIPTION
Not yet applied - need to coordinate with DNS change

Connected to https://github.com/notch8/dev-ops/issues/1097

- Update DNS to new ingress via Cloudflare terraform (see https://github.com/notch8/notch8-ops/blob/main/terraform/cloudflare/DNS_MANAGEMENT.md) - update `princeton-manifold-origin` entry under `notch8.cloud`
- Deploy this branch
- Validate that it's working (https://openpublishing.princeton.edu/) - may have to wait for restart & DNS to update, although it should be very quick.

See https://github.com/notch8/notch8-ops/blob/main/runbooks/ingress_migration.md for checks