### PR TITLE
Update to nginx-ingress - persist what is currently on production

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -15,20 +15,32 @@ readinessProbe:
 
 ingress:
   enabled: true
+  className: nginx-ingress
   hosts:
     - host: openpublishing.princeton.edu
       paths:
         - path: /
           pathType: ImplementationSpecific
+    # TODO: This origin hostname is currently required because Cloudflare Custom Hostnames
+    # sends the custom origin hostname as upstream SNI. Our ingress/origin certificate
+    # must continue to serve this hostname until the Cloudflare custom origin/SNI behavior
+    # is changed or the fallback/origin hostname strategy is removed.
+    # https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/custom-origin/
+    - host: princeton-manifold-origin.notch8.cloud
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod-nginx-ingress"
   tls:
+    # TODO: We can remove princeton-manifold-origin.notch8.cloud only after Cloudflare
+    # no longer sends that hostname as the upstream SNI value for this custom hostname.
+    # For now, the origin certificate must cover both:
     - hosts:
         - openpublishing.princeton.edu
+        - princeton-manifold-origin.notch8.cloud
       secretName: production-princeton-manifold-tls
-
 api:
   rails:
     replicaCount: 2


### PR DESCRIPTION
ref ticket # https://github.com/notch8/notch8-ops/issues/107
ref ticket # https://github.com/notch8/notch8-ops/pull/111

Update to nginx-ingress - persist what is currently on production

### PR Description

Updates ingress for `openpublishing.princeton.edu` to support migration to the new ingress while remaining compatible with Cloudflare Custom Hostnames.

### Context

During migration:

- Cloudflare fallback origin pointed to old ingress
- cert-manager HTTP01 challenges were created on old ingress
- Certificate issuance stalled (`Order pending`) when moving to new ingress

### Key Insight

Cloudflare sends the **custom origin hostname as SNI** and relies on a **single fallback origin**, which can conflict with HTTP01 validation during migration.

### Changes

- Ingress now serves:
  - `openpublishing.princeton.edu`
  - `princeton-manifold-origin.notch8.cloud`
- TLS certificate covers both hostnames

### Notes

- `princeton-manifold-origin.notch8.cloud` is temporarily required due to Cloudflare SNI behavior
- Can be removed once fallback/origin hostname dependency is eliminated

Ref: https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/custom-origin/