### PR TITLE
Increase sidekiq limits, reduce requests

### DIFF
--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -1,4 +1,7 @@
-replicaCount: 1
+autoscaling:
+  enabled: true
+  minReplicas: 0
+  maxReplicas: 2
 
 imagePullSecrets:
   - name: github
@@ -59,10 +62,10 @@ api:
   sidekiq:
     resources:
       limits:
-        memory: "10Gi"
+        memory: "16Gi"
         cpu: "1000m"
       requests:
-        memory: "7Gi"
+        memory: "2Gi"
         cpu: "800m"
 
 client:

--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -1,7 +1,4 @@
-autoscaling:
-  enabled: true
-  minReplicas: 0
-  maxReplicas: 2
+replicaCount: 1
 
 imagePullSecrets:
   - name: github

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -72,7 +72,7 @@ api:
   sidekiq:
     resources:
       limits:
-        memory: "6Gi"
+        memory: "16Gi"
         cpu: "1000m"
       requests:
         memory: "5Gi"


### PR DESCRIPTION
Sidekiq has momentary spikes in its memory use, which repeatedly kills the pod when processing large items. If we give it very high requests, it makes it very difficult to schedule. In general I believe the resource use is lower - it's just these small spikes that cause a problem.