### PR TITLE
i77-ingress-proxy-timeouts-for-large-uploads

### DIFF
--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -23,6 +23,8 @@ ingress:
           pathType: ImplementationSpecific
   annotations:
     nginx.org/client-max-body-size: "0"
+    nginx.org/proxy-read-timeout: "600"
+    nginx.org/proxy-send-timeout: "600"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
   tls:
     - hosts:

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -32,6 +32,8 @@ ingress:
           pathType: ImplementationSpecific
   annotations:
     nginx.org/client-max-body-size: "0"
+    nginx.org/proxy-read-timeout: "600"
+    nginx.org/proxy-send-timeout: "600"
     cert-manager.io/cluster-issuer: "letsencrypt-prod-nginx-ingress"
   tls:
     # TODO: We can remove princeton-manifold-origin.notch8.cloud only after Cloudflare


### PR DESCRIPTION
### Summary
Add timeout annotations to ingress for large file uploads.

- Added `proxy-read-timeout` and `proxy-send-timeout` annotations (600s) to ingress configuration
- Resolves timeout failures when uploading large files (e.g., 73MB PDFs) in the backend

### Changed Files
- ops/production-deploy.tmpl.yaml
- ops/friends-deploy.tmpl.yaml

### Test Plan
- [x] Verify 73MB PDF upload succeeds on production after runtime fix
- [ ] Confirm annotations persist after next Helm deployment


### After fix applied screenshot of successful upload
<details>

<img width="1510" height="861" alt="Screenshot 2026-05-29 at 9 54 50 AM" src="https://github.com/user-attachments/assets/abdbc3d7-fe61-4983-92ea-6fd2692caddb" />

</details>

### Technical Details

**Issue:**
Large file uploads (73MB+ PDFs) to resources were failing silently. Browser DevTools showed "Provisional headers are shown" with 0 bytes transferred - the request was timing out at the ingress layer before reaching Rails.

**Root Cause:**
The NGINX ingress controller has a default `proxy-read-timeout` of 60 seconds. For large file uploads over slower connections, this wasn't sufficient. While `client-max-body-size: "0"` (unlimited) was already set, the proxy timeout annotations were missing.

**Fix Applied:**
1. **Runtime fix (immediate):** Added annotations via `kubectl annotate ingress princeton-manifold-production`
2. **Permanent fix:** Added to Helm values in both deploy templates:

```yaml
annotations:
  nginx.org/client-max-body-size: "0"
  nginx.org/proxy-read-timeout: "600"    # 10 minutes
  nginx.org/proxy-send-timeout: "600"    # 10 minutes
  cert-manager.io/cluster-issuer: "..."
```

**Verification:**
- Confirmed 73MB PDF uploaded successfully after runtime fix
- Rails logs showed `PUT /api/v1/resources/bf0f373e-... status=200`
- Background jobs (ProcessAttachmentJob, ReindexV2Job) queued successfully

**Note:** The runtime fix is already active on production. This PR ensures the settings persist through future Helm deployments.
